### PR TITLE
Added try catch to prevent entire process from failing when facebook provides a bad image

### DIFF
--- a/download.js
+++ b/download.js
@@ -49,8 +49,14 @@ module.exports = function(albums, dest, photoSelector) {
                       "Error converting " + (photo.name || photo.id)
                     );
                   }
-
-                  var result = addExif(photo, buffer.toString("binary"));
+                  try {
+                    var result = addExif(photo, buffer.toString("binary"));
+                  }
+                  catch (error) {
+                    return debug(
+                      "Error adding exif data to " + (photo.name || photo.id)
+                    );
+                  }
 
                   fs.writeFile(filePath, result, "binary", function(err) {
                     if (err) {


### PR DESCRIPTION
Title says it all. Facebook sometimes returns a bad link which doesn't return a valid image. This was blocking me from downloading _any_ of my photos. This change notifies the user of the erroring image, and allows processing to continue.